### PR TITLE
fix: arithmetic increment crashes installer steps 5-7 under set -e

### DIFF
--- a/installers/install-claude.sh
+++ b/installers/install-claude.sh
@@ -185,7 +185,7 @@ else
   for cmd in "$PLUGIN_DIR/commands"/*.md; do
     if [ -f "$cmd" ]; then
       cp "$cmd" "$COMMANDS_DIR/$(basename "$cmd")"
-      ((CMD_COUNT++))
+      CMD_COUNT=$((CMD_COUNT + 1))
     fi
   done
 
@@ -217,7 +217,7 @@ else
         for agent in "$category"/*.md; do
           if [ -f "$agent" ]; then
             cp "$agent" "$AGENTS_DIR/$category_name/$(basename "$agent")"
-            ((AGENT_COUNT++))
+            AGENT_COUNT=$((AGENT_COUNT + 1))
           fi
         done
       fi
@@ -268,7 +268,7 @@ else
         # Copy entire skill directory (may contain references/, templates/, etc.)
         cp -r "$skill_dir" "$SKILLS_DIR/$skill_name"
         touch "$SKILLS_DIR/$skill_name/.lavra"
-        ((SKILL_COUNT++))
+        SKILL_COUNT=$((SKILL_COUNT + 1))
       fi
     done
   fi


### PR DESCRIPTION
## Problem

Steps 5, 6, and 7 of `install-claude.sh` exit silently on the first file they try to copy, leaving zero commands, agents, or skills installed.

The root cause is a classic bash gotcha: `((var++))` when `var=0` evaluates to `0` (the pre-increment value), which bash arithmetic treats as a falsy exit status (`1`). With `set -euo pipefail` active at the top of the script, this causes an immediate exit.

Affected counters:

| Step | Variable | Line |
|------|----------|------|
| 5 — Install commands | `CMD_COUNT` | 188 |
| 6 — Install agents | `AGENT_COUNT` | 221 |
| 7 — Install skills | `SKILL_COUNT` | 270 |

## Fix

Replace `((var++))` with `var=$((var + 1))` for all three counters. The POSIX arithmetic substitution form always exits `0`, so it is safe under `set -e`.

```bash
# Before (exits 1 when var=0, killing the script)
((CMD_COUNT++))

# After (always exits 0)
CMD_COUNT=$((CMD_COUNT + 1))
```

## Testing

Run the installer against a fresh test project and verify all three steps complete with non-zero counts:

```bash
mkdir -p /tmp/test-install && cd /tmp/test-install
git init -q
bash /path/to/lavra/install.sh /tmp/test-install --yes
# Steps 5, 6, 7 should report installed counts > 0
```

---

[![Compound Engineering v2.40.0](https://img.shields.io/badge/Compound_Engineering-v2.40.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 (200K context) via [Claude Code](https://claude.ai/code)