### PR TITLE
fix(memory-capture): scope extraction to first matching bd comment line

### DIFF
--- a/plugins/lavra/hooks/memory-capture.sh
+++ b/plugins/lavra/hooks/memory-capture.sh
@@ -28,12 +28,28 @@ if [[ -n "$CLAUDE_PROJECT_DIR" ]]; then
   fi
 fi
 
-# Extract BEAD_ID
-BEAD_ID=$(echo "$COMMAND" | sed -E 's/.*bd[[:space:]]+comments?[[:space:]]+add[[:space:]]+([A-Za-z0-9._-]+)[[:space:]]+.*/\1/')
-[[ -z "$BEAD_ID" || "$BEAD_ID" == "$COMMAND" ]] && exit 0
+# Scope extraction to the first bd comments add line that contains a knowledge prefix.
+# Running on the full COMMAND causes two bugs when multiple commands are chained (&&, ;, newlines):
+#   1. BEAD_ID: sed passes non-matching lines through unchanged, polluting the value with
+#      subsequent shell commands (e.g. "bd close ... 2>&1 | grep ...").
+#   2. COMMENT_BODY: the greedy .* matches to the *last* bd comments add in the string,
+#      concatenating all comment bodies into one blob with embedded shell operators.
+MATCH_LINE=$(echo "$COMMAND" \
+  | grep -E 'bd[[:space:]]+comments?[[:space:]]+add[[:space:]]+' \
+  | grep -m1 -E '(INVESTIGATION:|LEARNED:|DECISION:|FACT:|PATTERN:|DEVIATION:)')
+[[ -z "$MATCH_LINE" ]] && exit 0
 
-# Extract comment body
-COMMENT_BODY=$(echo "$COMMAND" | sed -E 's/.*bd[[:space:]]+comments?[[:space:]]+add[[:space:]]+[A-Za-z0-9._-]+[[:space:]]+["'\'']//' | sed -E 's/["'\''][[:space:]]*$//' | head -c 4096)
+# Extract BEAD_ID from that line only
+BEAD_ID=$(echo "$MATCH_LINE" | sed -E 's/.*bd[[:space:]]+comments?[[:space:]]+add[[:space:]]+([A-Za-z0-9._-]+)[[:space:]]+.*/\1/')
+[[ -z "$BEAD_ID" || "$BEAD_ID" == "$MATCH_LINE" ]] && exit 0
+
+# Extract comment body: strip prefix up to opening quote, then strip from the
+# closing quote onward (handles trailing 2>&1, &&, |, ; operators)
+COMMENT_BODY=$(echo "$MATCH_LINE" \
+  | sed -E 's/.*bd[[:space:]]+comments?[[:space:]]+add[[:space:]]+[A-Za-z0-9._-]+[[:space:]]+["'\'']//' \
+  | sed -E 's/["'\''][[:space:]]*(2>&1|&&|\||;).*$//' \
+  | sed -E 's/["'\''][[:space:]]*$//' \
+  | head -c 4096)
 [[ -z "$COMMENT_BODY" ]] && exit 0
 
 # Detect type from prefix


### PR DESCRIPTION
## Problem

When multiple commands are chained in one Bash tool call (`&&`, `;`, or newlines), `memory-capture.sh` produces corrupted knowledge entries in two ways:

**Bug 1 — BEAD_ID pollution**

`sed` is line-scoped: lines that don't match a pattern pass through unchanged. For a command like:

```bash
bd comments add my-bead "FACT: something" 2>&1 | grep "Added"
bd close my-bead 2>&1 | grep "Closed"
```

The `BEAD_ID` variable ends up as:
```
my-bead
bd close my-bead 2>&1 | grep "Closed"
```

This is visible in `knowledge.jsonl` as `bead` fields containing entire shell pipelines.

**Bug 2 — COMMENT_BODY blob**

The greedy `.*` in the `sed` extraction pattern matches to the **last** `bd comments add` in the full command string. When the close quote is followed by shell operators (`2>&1`, `&&`, `|`) rather than end-of-string, the trailing-quote strip fails. All comment bodies in the command get concatenated into one entry with embedded shell syntax.

## Fix

Scope extraction to the first `bd comments add` line in the command that contains a knowledge prefix, using `grep` (which is line-scoped by default):

```bash
MATCH_LINE=$(echo "$COMMAND" \
  | grep -E 'bd[[:space:]]+comments?[[:space:]]+add[[:space:]]+' \
  | grep -m1 -E '(INVESTIGATION:|LEARNED:|DECISION:|FACT:|PATTERN:|DEVIATION:)')
```

Then extract `BEAD_ID` and `COMMENT_BODY` from that single line only. A third `sed` pass strips trailing shell operators (`2>&1`, `&&`, `|`, `;`) after the closing quote.

**Tradeoff:** when multiple knowledge comments are logged in one Bash call, only the first is captured. The expected usage pattern is one `bd comments add` per Bash call; this fix makes that expectation explicit.